### PR TITLE
fix(ime): :bug: Fix IME support for wayland

### DIFF
--- a/com.vscodium.codium-insiders.yaml
+++ b/com.vscodium.codium-insiders.yaml
@@ -178,8 +178,7 @@ modules:
     sources:
       - type: git
         url: https://github.com/flathub-infra/ide-flatpak-wrapper.git
-        branch: zypak
-        commit: ea2cf2d69d4f95f886170417af3a50a9c6c88e2f
+        commit: c26e15940a02b40603ea57b0ac76b4944bee5464
       - type: file
         path: README.md
       - type: file

--- a/com.vscodium.codium-insiders.yaml
+++ b/com.vscodium.codium-insiders.yaml
@@ -178,7 +178,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/flathub-infra/ide-flatpak-wrapper.git
-        commit: 7b72347aad88e21a49d6d5299fcd94cedd16624a
+        branch: zypak
+        commit: ea2cf2d69d4f95f886170417af3a50a9c6c88e2f
       - type: file
         path: README.md
       - type: file


### PR DESCRIPTION
After the latest update 
- electron was updated to 34 with text-input-version v3 added for wayland ime support
- Added "--wayland-text-input-version=3" to `ide-flatpak-wrapper`