### PR TITLE
package.json: change desktopName to com.vscodium.codium-insiders

### DIFF
--- a/patches/package.json.patch
+++ b/patches/package.json.patch
@@ -5,5 +5,5 @@
 -  "desktopName": "codium-insiders.desktop"
 -}
 \ No newline at end of file
-+  "desktopName": "com.vscodium.codium-insiders-url-handler.desktop"
++  "desktopName": "com.vscodium.codium-insiders.desktop"
 +}


### PR DESCRIPTION
as per https://github.com/flathub/com.vscodium.codium/pull/444 this will allow wayland desktop environments to target the correct desktop file